### PR TITLE
Multiple class selectors and fixes nested tag selector bug

### DIFF
--- a/lib/soupselect.js
+++ b/lib/soupselect.js
@@ -124,7 +124,7 @@ exports.select = function(dom, selector) {
                 if (!value) return false;
                 var classes = value.split(/\s+/);
                 for (var i = 1, len = parts.length; i < len; i++) {
-                    if (!~classes.indexOf(parts[i]) return false;
+                    if (!~classes.indexOf(parts[i])) return false;
                 }
                 return true;
             };
@@ -160,13 +160,13 @@ exports.select = function(dom, selector) {
             found = [];
             for ( var m = 0; m < currentContext.length; m++ ) {
                 // htmlparsers document itself has no child property - only nodes do...
-                if ( typeof context.children !== 'undefined' ) {
+                if ( typeof currentContext[m].children !== 'undefined' ) {
                     found = found.concat(domUtils.getElementsByTagName(tokens[i], currentContext[m].children));
-                } else {
+                } else if (i === 0) {
                     found = found.concat(domUtils.getElementsByTagName(tokens[i], currentContext[m]));
                 }
 
-            });
+            };
             
             currentContext = found;
         }


### PR DESCRIPTION
I've added support for multiple class selectors, e.g. "p.class1.class2"

I've also fixed a bug where nested tag selectors, e.g. "p p", weren't working.

See [https://gist.github.com/662201](https://gist.github.com/662201) for the behavior before and after
