### PR TITLE
Export select at root

### DIFF
--- a/lib/soupselect.js
+++ b/lib/soupselect.js
@@ -53,7 +53,7 @@ the provided selector against. The returned value is also
 a valid dom tree, so can be passed by into 
 htmlparser.DomUtil.* calls
 */
-exports.select = function(dom, selector) {
+exports = exports.select = function(dom, selector) {
     var currentContext = [dom];
     var found, tag, options;
     


### PR DESCRIPTION
Hi Harry. Thanks for the module. This change is just for convenience—export the select function at root too, so users can do soupselect() rather than the tautological soupselect.select(). This is conventional, the modules `socket.io` and `zappa` do this sort of thing.
-Matt
