### PR TITLE
node(sys) deprecated. Changed all sys.debug() calls to console.error()

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,7 @@ A complete example including fetching HTML etc...;
 
     var select = require('soupselect').select,
         htmlparser = require("htmlparser"),
-        http = require('http'),
-        sys = require('sys');
+        http = require('http');
 
     // fetch some HTML...
     var http = require('http');
@@ -28,23 +27,23 @@ A complete example including fetching HTML etc...;
 
     request.on('response', function (response) {
         response.setEncoding('utf8');
-    
+
         var body = "";
         response.on('data', function (chunk) {
             body = body + chunk;
         });
-    
+
         response.on('end', function() {
-        
+
             // now we have the whole body, parse it and select the nodes we want...
             var handler = new htmlparser.DefaultHandler(function(err, dom) {
                 if (err) {
-                    sys.debug("Error: " + err);
+                    console.error("Error: " + err);
                 } else {
-                
+
                     // soupselect happening here...
                     var titles = select(dom, 'a.title');
-                
+
                     sys.puts("Top stories from reddit");
                     titles.forEach(function(title) {
                         sys.puts("- " + title.children[0].raw + " [" + title.attribs.href + "]\n");

--- a/benchmark.js
+++ b/benchmark.js
@@ -5,8 +5,7 @@ but only runs those tests where the CSS syntax used is supported by soupselect
 
 var select = require('soupselect').select,
     htmlparser = require("htmlparser"),
-    fs = require('fs'),
-    sys = require('sys');
+    fs = require('fs');
 
 var html = fs.readFileSync('testdata/benchmark.html', 'utf-8');
 
@@ -34,10 +33,10 @@ var selectors = [
     ];
 
 selectors.forEach(function(selector) {
-    
+
     var handler = new htmlparser.DefaultHandler(function(err, dom) {
         if (err) {
-            sys.debug("Error: " + err);
+            console.error("Error: " + err);
         } else {
             var start = new Date().getTime();
             var els = select(dom, selector);
@@ -48,5 +47,5 @@ selectors.forEach(function(selector) {
 
     var parser = new htmlparser.Parser(handler);
     parser.parseComplete(html);
-    
+
 });

--- a/example.js
+++ b/example.js
@@ -1,33 +1,32 @@
     var select = require('./lib/soupselect').select,
         htmlparser = require("htmlparser"),
-        http = require('http'),
-        sys = require('sys');
-    
+        http = require('http');
+
     // fetch some HTML...
     var http = require('http');
     var host = 'www.reddit.com';
     var client = http.createClient(80, host);
     var request = client.request('GET', '/',{'host': host});
-    
+
     request.on('response', function (response) {
         response.setEncoding('utf8');
-        
+
         var body = "";
         response.on('data', function (chunk) {
             body = body + chunk;
         });
-        
+
         response.on('end', function() {
-            
+
             // now we have the whole body, parse it and select the nodes we want...
             var handler = new htmlparser.DefaultHandler(function(err, dom) {
                 if (err) {
-                    sys.debug("Error: " + err);
+                    console.error("Error: " + err);
                 } else {
-                    
+
                     // soupselect happening here...
                     var titles = select(dom, 'a.title');
-                    
+
                     sys.puts("Top stories from reddit");
                     titles.forEach(function(title) {
                         sys.puts("- " + title.children[0].raw + " [" + title.attribs.href + "]\n");

--- a/lib/soupselect.js
+++ b/lib/soupselect.js
@@ -6,7 +6,6 @@ MIT licensed http://www.opensource.org/licenses/mit-license.php
 */
 
 var domUtils = require("htmlparser").DomUtils;
-var sys = require('sys');
 
 var tagRe = /^[a-z0-9]+$/;
 
@@ -16,7 +15,7 @@ var tagRe = /^[a-z0-9]+$/;
      |      |         |               |
      |      |         |           The value
      |      |    ~,|,^,$,* or =
-     |   Attribute 
+     |   Attribute
     Tag
 */
 var attrSelectRe = /^(\w+)?\[(\w+)([=~\|\^\$\*]?)=?"?([^\]"]*)"?\]$/;
@@ -28,7 +27,7 @@ Used to checking attribute values for attribute selectors
 */
 function makeValueChecker(operator, value) {
     value = typeof(value) === 'string' ? value : '';
-    
+
     return operator ? {
         '=': function ( test_value ) { return test_value === value; },
         // attribute includes value as one of a set of space separated tokens
@@ -50,17 +49,17 @@ function makeValueChecker(operator, value) {
 /**
 Takes a dom tree or part of one from htmlparser and applies
 the provided selector against. The returned value is also
-a valid dom tree, so can be passed by into 
+a valid dom tree, so can be passed by into
 htmlparser.DomUtil.* calls
 */
 exports.select = function(dom, selector) {
     var currentContext = [dom];
     var found, tag, options;
-    
+
     var tokens = selector.split(/\s+/);
-    
+
     for ( var i = 0; i < tokens.length; i++ ) {
-        
+
         // Attribute selectors
         var match = attrSelectRe.exec(tokens[i]);
         if ( match ) {
@@ -68,31 +67,31 @@ exports.select = function(dom, selector) {
             tag = match[1];
             options = {};
             options[attribute] = makeValueChecker(operator, value);
-            
+
             found = [];
             for (var j = 0; j < currentContext.length; j++ ) {
                 found = found.concat(domUtils.getElements(options, currentContext[j]));
             };
-            
+
             if ( tag ) {
                 // Filter to only those matching the tag name
                 found = domUtils.getElements({ 'tag_name': tag }, found, false);
             }
-        
+
             currentContext = found;
-        
-        } 
-    
+
+        }
+
         // ID selector
         else if ( tokens[i].indexOf('#') !== -1 ) {
             found = [];
-            
+
             var id_selector = tokens[i].split('#', 2)[1];
-            
+
             // need to stop on the first id found (in bad HTML)...
             var el = null;
             for ( var k = 0; k < currentContext.length; k++ ) {
-                
+
                 // the document has no child elements but tags do so we search children to avoid
                 // returning the current element via a false positive
                 if ( typeof currentContext[k].children !== 'undefined' ) {
@@ -106,15 +105,15 @@ exports.select = function(dom, selector) {
                     break;
                 }
             }
-            
+
             if (!found[0]) {
                 currentContext = [];
                 break;
             }
-            
+
             currentContext = found;
         }
-        
+
         // Class selector
         else if ( tokens[i].indexOf('.') !== -1 ) {
             var parts = tokens[i].split('.');
@@ -128,7 +127,7 @@ exports.select = function(dom, selector) {
                 }
                 return true;
             };
-            
+
             found = [];
             for ( var l = 0; l < currentContext.length; l++ ) {
                 var context = currentContext[l];
@@ -139,24 +138,24 @@ exports.select = function(dom, selector) {
                 } else {
                     found = found.concat(domUtils.getElements(options, context));
                 }
-                
+
             };
-            
+
             currentContext = found;
         }
-        
+
         // Star selector
         else if ( tokens[i] === '*' ) {
             // nothing to do right?
         }
-        
+
         // Tag selector
         else {
             if (!tagRe.test(tokens[i])) {
                 currentContext = [];
                 break;
             }
-            
+
             found = [];
             for ( var m = 0; m < currentContext.length; m++ ) {
                 // htmlparsers document itself has no child property - only nodes do...
@@ -167,10 +166,10 @@ exports.select = function(dom, selector) {
                 }
 
             };
-            
+
             currentContext = found;
         }
     };
-    
+
     return currentContext;
 };

--- a/tests/soupselect.js
+++ b/tests/soupselect.js
@@ -1,14 +1,13 @@
 var select = require('soupselect').select,
     htmlparser = require("htmlparser"),
-    fs = require('fs'),
-    sys = require('sys');
+    fs = require('fs');
 
 var html = fs.readFileSync('testdata/test.html', 'utf-8');
 
 function runTest(test, callback) {
     var handler = new htmlparser.DefaultHandler(function(err, dom) {
         if (err) {
-            sys.debug("Error: " + err);
+            console.error("Error: " + err);
         } else {
             callback(dom);
         }
@@ -52,7 +51,7 @@ exports.basicSelectors = {
         });
         test.done();
     },
-    
+
     one_tag_many: function(test) {
         runTest(test, function(dom) {
             var els = select(dom, 'div');
@@ -63,21 +62,21 @@ exports.basicSelectors = {
         });
         test.done();
     },
-    
+
     tag_in_tag_one: function(test) {
         runTest(test, function(dom) {
             assertSelects(test, dom, 'div div', ['inner']);
         });
         test.done();
     },
-    
+
     tags_in_tags: function(test) {
         runTest(test, function(dom) {
             assertSelects(test, dom, 'span span', ['yx', 'yy']);
         });
         test.done();
     },
-    
+
     tag_in_tag_many: function(test) {
         ['html div', 'html body div', 'body div'].forEach(function(selector) {
             runTest(test, function(dom) {
@@ -86,21 +85,21 @@ exports.basicSelectors = {
         });
         test.done();
     },
-    
+
     tag_no_match: function(test) {
         runTest(test, function(dom) {
             test.equal(select(dom, 'del').length, 0);
         });
         test.done();
     },
-    
+
     tag_invalid_tag: function(test) {
         runTest(test, function(dom) {
             test.equal(select(dom, 'tag%t').length, 0);
         });
         test.done();
     },
-    
+
     header_tags: function(test) {
         runTest(test, function(dom) {
             assertSelectMultiple(test, dom, [
@@ -110,7 +109,7 @@ exports.basicSelectors = {
         });
         test.done();
     },
-    
+
     class_one: function(test) {
         runTest(test, function(dom) {
             ['.onep', 'p.onep', 'html p.onep'].forEach(function(selector) {
@@ -122,7 +121,7 @@ exports.basicSelectors = {
         });
         test.done();
     },
-    
+
     class_mismatched_tag: function(test) {
         runTest(test, function(dom) {
             var els = select(dom, 'div.onep');
@@ -130,7 +129,7 @@ exports.basicSelectors = {
         });
         test.done();
     },
-    
+
     multi_class: function(test) {
         runTest(test, function(dom) {
             var els = select(dom, 'p.class1.class2.class3');
@@ -138,7 +137,7 @@ exports.basicSelectors = {
         });
         test.done();
     },
-    
+
     one_id: function(test) {
         runTest(test, function(dom) {
             ['div#inner', '#inner', 'div div#inner'].forEach(function(selector) {
@@ -147,7 +146,7 @@ exports.basicSelectors = {
         });
         test.done();
     },
-    
+
     bad_id: function(test) {
         runTest(test, function(dom) {
             var els = select(dom, '#doesnotexist');
@@ -155,7 +154,7 @@ exports.basicSelectors = {
         });
         test.done();
     },
-    
+
     items_in_id: function(test) {
         runTest(test, function(dom) {
             var els = select(dom, 'div#inner p');
@@ -164,13 +163,13 @@ exports.basicSelectors = {
                 test.equal(el.name, 'p');
             });
             test.equal(els[1].attribs.class, 'onep');
-            
+
             // attribs not created when none around - should really be checking there's no class attribute
             test.ok(typeof els[0].attribs == 'undefined');
             test.done();
         });
     },
-    
+
     a_bunch_of_emptys: function(test) {
         runTest(test, function(dom) {
             ['div#main del', 'div#main div.oops', 'div div#main'].forEach(function(selector) {
@@ -179,10 +178,10 @@ exports.basicSelectors = {
         });
         test.done();
     },
-    
+
     multi_class_support: function(test) {
         runTest(test, function(dom) {
-            ['.class1', 'p.class1', '.class2', 'p.class2', 
+            ['.class1', 'p.class1', '.class2', 'p.class2',
                 '.class3', 'p.class3', 'html p.class2',
                     'div#inner .class2'].forEach(function(selector) {
                 assertSelects(test, dom, selector, ['pmulti']);
@@ -190,11 +189,11 @@ exports.basicSelectors = {
         });
         test.done();
     },
-    
+
 }
 
 exports.attributeSelectors = {
-    
+
     attribute_equals: function(test) {
         runTest(test, function(dom) {
             assertSelectMultiple(test, dom, [
@@ -216,7 +215,7 @@ exports.attributeSelectors = {
         });
         test.done();
     },
-    
+
     attribute_tilde: function(test) {
         runTest(test, function(dom) {
             assertSelectMultiple(test, dom, [
@@ -234,7 +233,7 @@ exports.attributeSelectors = {
         });
         test.done();
     },
-    
+
     attribute_startswith: function(test) {
         runTest(test, function(dom) {
             assertSelectMultiple(test, dom, [
@@ -254,7 +253,7 @@ exports.attributeSelectors = {
         });
         test.done();
     },
-    
+
     attribute_endswith: function(test) {
         runTest(test, function(dom) {
             assertSelectMultiple(test, dom, [
@@ -268,7 +267,7 @@ exports.attributeSelectors = {
         });
         test.done();
     },
-    
+
     attribute_contains: function(test) {
         runTest(test, function(dom) {
             assertSelectMultiple(test, dom, [
@@ -301,7 +300,7 @@ exports.attributeSelectors = {
         });
         test.done();
     },
-    
+
     attribute_exact_or_hypen: function(test) {
         runTest(test, function(dom) {
             assertSelectMultiple(test, dom, [
@@ -313,7 +312,7 @@ exports.attributeSelectors = {
         });
         test.done();
     },
-    
+
     attribute_exists: function(test) {
         runTest(test, function(dom) {
             assertSelectMultiple(test, dom, [


### PR DESCRIPTION
So I don't have to see the `(node) sys is deprecated. Use util instead.` every time I run my code.
