### PR TITLE
Fix warning and unused variable

### DIFF
--- a/lib/soupselect.js
+++ b/lib/soupselect.js
@@ -6,7 +6,6 @@ MIT licensed http://www.opensource.org/licenses/mit-license.php
 */
 
 var domUtils = require("htmlparser").DomUtils;
-var sys = require('sys');
 
 var tagRe = /^[a-z0-9]+$/;
 


### PR DESCRIPTION
Fixes:
 - (node:34749) [DEP0025] DeprecationWarning: sys is deprecated. Use util instead.
 - Unused variable

Instead of changing it to use the "util" module, I've removed the variable because it's not being used!
